### PR TITLE
macOS and Linux portability

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,8 @@ READTAPE_OBJS = decoder.o readtape.o parmsets.o decode_ww.o \
 				textfile.o decode_nrzi.o decode_pe.o \
 				decode_gcr.o tapread.o ibmlabels.o trace.o
 
-CFLAGS = -Wall -Wno-unused-variable -Wno-unused-but-set-variable
+CFLAGS += --std=c99 -Wall -Wno-unused-variable -Wno-unused-but-set-variable -D_DEFAULT_SOURCE
+LDFLAGS += -lm
 
 .PHONY: all clean
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,23 @@
+EXECUTABLES = csvtbin dumptap readtape 
+READTAPE_OBJS = decoder.o readtape.o parmsets.o decode_ww.o \
+				textfile.o decode_nrzi.o decode_pe.o \
+				decode_gcr.o tapread.o ibmlabels.o trace.o
+
+CFLAGS = -Wall -Wno-unused-variable -Wno-unused-but-set-variable
+
+.PHONY: all clean
+
+all: $(EXECUTABLES)
+
+dumptap: dumptap.o
+	$(CC) $(LDFLAGS) -o $@ $^
+csvtbin: csvtbin.o
+	$(CC) $(LDFLAGS) -o $@ $^
+readtape: $(READTAPE_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $^
+
+clean:
+	rm -f $(EXECUTABLES) $(READTAPE_OBJS) dumptap.o csvtbin.o

--- a/src/csvtbin.c
+++ b/src/csvtbin.c
@@ -169,6 +169,22 @@ void fatal(const char *msg, ...) {
    va_start(args, msg);
    vfatal(msg, args); }
 
+char * asctime_unix(const struct tm_unix *timeptr)
+{
+  struct tm newtmx;
+  newtmx.tm_sec = timeptr->tm_sec;
+  newtmx.tm_min = timeptr->tm_min;
+  newtmx.tm_hour = timeptr->tm_hour;
+  newtmx.tm_mday = timeptr->tm_mday;
+  newtmx.tm_mon = timeptr->tm_mon;
+  newtmx.tm_year = timeptr->tm_year;
+  newtmx.tm_wday = timeptr->tm_wday;
+  newtmx.tm_isdst = timeptr->tm_isdst;
+  newtmx.tm_zone = "UTC";
+  newtmx.tm_gmtoff = 0;
+  return asctime(&newtmx);
+}
+
 /********************************************************************
 Routines for processing options
 *********************************************************************/
@@ -499,9 +515,9 @@ void read_tbin(void) {
              hdr.u.s.bpi, hdr.u.s.ips, (float)hdr.u.s.tdelta / 1e3);
    logprintf("the track ordering was%s given when the .tbin file was created\n", hdr.u.s.flags & TBIN_NO_REORDER ? " not" : "");
    logprintf("description: %s\n", hdr.descr);
-   if (hdr.u.s.time_written.tm_year > 0)   logprintf("created on:   %s", asctime(&hdr.u.s.time_written));
-   if (hdr.u.s.time_read.tm_year > 0)      logprintf("read on:      %s", asctime(&hdr.u.s.time_read));
-   if (hdr.u.s.time_converted.tm_year > 0) logprintf("converted on: %s", asctime(&hdr.u.s.time_converted));
+   if (hdr.u.s.time_written.tm_year > 0)   logprintf("created on:   %s", asctime_unix(&hdr.u.s.time_written));
+   if (hdr.u.s.time_read.tm_year > 0)      logprintf("read on:      %s", asctime_unix(&hdr.u.s.time_read));
+   if (hdr.u.s.time_converted.tm_year > 0) logprintf("converted on: %s", asctime_unix(&hdr.u.s.time_converted));
    if (hdr.u.s.flags & TBIN_INVERTED) logprintf("the data was inverted\n");
    if (hdr.u.s.flags & TBIN_REVERSED) logprintf("the tape might have been read or written backwards\n");
    if (hdr.u.s.flags & TBIN_TRKORDER_INCLUDED) { // optional trkorder heaader extension?
@@ -567,7 +583,8 @@ void write_tbin_hdr(void) {
    time_t start_time;
    time(&start_time);
    struct tm *ptm = localtime(&start_time);
-   hdr.u.s.time_converted = *ptm;  // structure copy!
+#warning FIXME time time_converted
+//   hdr.u.s.time_converted = *ptm;  // structure copy!
    hdr.u.s.ntrks = ntrks;
    assert(fwrite(hdr.tag, sizeof(hdr.tag)+sizeof(hdr.descr), 1, outf) == 1, "can't write hdr tag/descr");
    for (int i = 0; i < sizeof(hdr.u.s) / 4; ++i)

--- a/src/csvtbin.c
+++ b/src/csvtbin.c
@@ -265,7 +265,7 @@ bool opt_64int(const char* arg, const char* keyword, uint64_t *pval, uint64_t mi
    if (strlen(arg) == 0) return true;  // allow and ignore if null
    uint64_t num;
    unsigned nch;
-   if (sscanf(arg, "%llu%n", &num, &nch) != 1
+   if (sscanf(arg, "%" PRIu64 "%n", &num, &nch) != 1
          || num < min || num > max || arg[nch] != '\0') fatal("bad integer: %s", arg);
    *pval = num;
    return true; }
@@ -712,7 +712,7 @@ void write_tbin(void) {
          if (++num_samples >= stopaft) break;
          if (sample_time > endtime) break;
          if (graphbin && tries == 0 && ++num_graph_vals >= graphbin) {
-            fprintf(graphf, "%llu, %f\n", num_samples, graphbin_max);
+            fprintf(graphf, "%" PRIu64 ", %f\n", num_samples, graphbin_max);
             graphbin_max = 0;
             num_graph_vals = 0; }
          update_progress_count(); }
@@ -735,8 +735,8 @@ done:
          num_samples = progress_count = 0;
          total_time = 0;
          fclose(inf); fclose(outf);
-         assert(inf = fopen(infilename, "r"), "unable to reopen input file\"%s\"", infilename);
-         assert(outf = fopen(outfilename, "wb"), "unable to reopen output file\"%s\"", outfilename); }
+         assert((inf = fopen(infilename, "r")), "unable to reopen input file\"%s\"", infilename);
+         assert((outf = fopen(outfilename, "wb")), "unable to reopen output file\"%s\"", outfilename); }
       else
          return;// all sample voltages were less than maxvolts
    } };

--- a/src/csvtbin.c
+++ b/src/csvtbin.c
@@ -121,7 +121,7 @@ typedef unsigned char byte;
 #define MINTRKS 5
 #define PREREAD_COUNT 1000000
 
-FILE *inf, *outf, *graphf, *logf;
+FILE *inf, *outf, *graphf, *csvlogf;
 char *basefilename;
 char infilename[MAXPATH], outfilename[MAXPATH], graphfilename[MAXPATH], logfilename[MAXPATH];
 uint64_t num_samples = 0;
@@ -148,13 +148,13 @@ void logprintf(const char *msg, ...) {
    va_list args2;
    va_copy(args2, args);
    vfprintf(stdout, msg, args);  // to the console
-   if (logf) vfprintf(logf, msg, args2); // and maybe also the log file
+   if (csvlogf) vfprintf(csvlogf, msg, args2); // and maybe also the log file
    va_end(args2); }
 
 void vfatal(const char *msg, va_list args) {
    logprintf("\n***FATAL ERROR: ");
    vprintf(msg, args);
-   if (logf) vfprintf(logf, msg, args);
+   if (csvlogf) vfprintf(csvlogf, msg, args);
    logprintf("\n");
    exit(99); }
 
@@ -739,9 +739,9 @@ int main(int argc, char *argv[]) {
 
    strncpy(logfilename, basefilename, MAXPATH - 15); logfilename[MAXPATH - 15] = 0;
    strcat(logfilename, ".csvtbin.log");
-   logf = fopen(logfilename, "w");
-   assert(logf, "file create failed for %s", logfilename);
-   fprintf(logf, "CSVTBIN version %s compiled on %s at %s\n", VERSION, __DATE__, __TIME__);
+   csvlogf = fopen(logfilename, "w");
+   assert(csvlogf, "file create failed for %s", logfilename);
+   fprintf(csvlogf, "CSVTBIN version %s compiled on %s at %s\n", VERSION, __DATE__, __TIME__);
    logprintf("command line: ");
    for (int i = 0; i < argc; ++i)  // for documentation, show invocation options
       logprintf("%s ", argv[i]);

--- a/src/csvtbin.h
+++ b/src/csvtbin.h
@@ -24,13 +24,25 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************************************************************/
-
+#pragma pack(push,1)
 #define TBIN_FILE_FORMAT 1
 #define MAXTRKS 19 // should be one less than a multiple of 4, 
 //                 // for machine-independent alignment of data structures here.
 
-//**** beware that changing these definitions may invalidate existing files!
+struct tm_unix {
+        int     tm_sec;         /* seconds after the minute [0-60] */
+        int     tm_min;         /* minutes after the hour [0-59] */
+        int     tm_hour;        /* hours since midnight [0-23] */
+        int     tm_mday;        /* day of the month [1-31] */
+        int     tm_mon;         /* months since January [0-11] */
+        int     tm_year;        /* years since 1900 */
+        int     tm_wday;        /* days since Sunday [0-6] */
+        int     tm_yday;        /* days since January 1 [0-365] */
+        int     tm_isdst;       /* Daylight Savings Time flag */
+};
 
+
+//**** beware that changing these definitions may invalidate existing files!
 enum mode_t {
    UNKNOWN = 0, PE = 0x01, NRZI = 0x02, GCR = 0x04, WW = 0x08,
    ALLMODES = PE + NRZI + GCR + WW };
@@ -43,9 +55,9 @@ struct tbin_hdr_t {     // the file header for .tbin files, which appears once
       struct { // everything in this struct must be 4-byte numbers, stored little-endian
          uint32_t tbinhdrsize;      // size of this header in bytes
          uint32_t format;           // .tbin file format version
-         struct tm time_written;    // when the analog tape data was written (9 integers)
-         struct tm time_read;       // when the analog tape data was digitized (9 integers)
-         struct tm time_converted;  // when the digitized data was converted to .tbin (9 integers)
+         struct tm_unix time_written;    // when the analog tape data was written (9 integers)
+         struct tm_unix time_read;       // when the analog tape data was digitized (9 integers)
+         struct tm_unix time_converted;  // when the digitized data was converted to .tbin (9 integers)
          uint32_t flags;            // file format flags, TBIN_xxx
 #define TBIN_NO_REORDER 0x01           //  tracks weren't reordered with -order=
 #define TBIN_TRKORDER_INCLUDED 0x02    //  the "trkorder" header extension follows this header
@@ -82,6 +94,7 @@ struct tbin_dat_t {     // the data header that starts each block of data
    byte rsvd1, rsvd2;               // reserved fields so that the next field is on an 8-byte boundary
    uint64_t tstart;                 // time of the next sample in nanoseconds, relative to the start of the tape
 };
+#pragma pack(pop)
 // What follows are multiple sets of "ntrks" packed little-endian signed integers,
 // in the track (head) order msb..lsb,parity.
 // Each integer is "sample_bits" long, and encodes the read head voltage for a sample in the range

--- a/src/decode_gcr.c
+++ b/src/decode_gcr.c
@@ -458,7 +458,7 @@ void gcr_get_sgroups(void) {
    for (bitnum = 0; bitnum < 5; ++bitnum) {
       dataword = data[gcr_bitnum + bitnum];
       trk = 9; do {
-         gcr_sgroup[trk - 1] = (gcr_sgroup[trk - 1] << 1) & (byte)0x1f | (dataword & 1);
+         gcr_sgroup[trk - 1] = ((gcr_sgroup[trk - 1] << 1) & (byte)0x1f) | (dataword & 1);
          dataword >>= 1; }
       while (--trk); } }
 

--- a/src/decode_nrzi.c
+++ b/src/decode_nrzi.c
@@ -96,8 +96,8 @@ void nrzi_end_of_block(void) {
    // see what we think this is, based on the length
    if ( // maybe it's a tapemark, which is pretty bizarre
       result->minbits == 9 // the initial 1-bit plus 8 bits of post-block
-      && (ntrks == 9 && data[0] == 0x26 && data[8] == 0x26  // 9 trk: trks 367, then 7 bits of zeros, then 367
-          ||  ntrks == 7 && data[0] == 0x1e && (data[3] == 0x1e || data[4] == 0x1e))) { // 7trk: trks 8421, then 2 or 3 bits of zeros, then 8421
+      && ((ntrks == 9 && data[0] == 0x26 && data[8] == 0x26)  // 9 trk: trks 367, then 7 bits of zeros, then 367
+          ||  (ntrks == 7 && data[0] == 0x1e && (data[3] == 0x1e || data[4] == 0x1e)))) { // 7trk: trks 8421, then 2 or 3 bits of zeros, then 8421
       result->blktype = BS_TAPEMARK; }
    else if (result->maxbits <= NRZI_MIN_BLOCK) {  // too small, but not tapemark: just noise
       dlog("   detected noise block of length %d at %.8lf\n", result->maxbits, timenow);

--- a/src/decode_pe.c
+++ b/src/decode_pe.c
@@ -128,7 +128,7 @@ void pe_preamble_peak(struct trkstate_t *t, bool is_top) {
    // process a peak during the preamble, and see if it is a one-bit that starts the data
    if (t->peakcount == 1) {  // the first transition, which is a 0-bit, sets the bit polarity
       t->bit1_up = !is_top; // (normally 1 is up, but might be reversed depending on logic analyzer polarity)
-      static warned_polarity = false; // should be in a file-specific structure
+      static int warned_polarity = false; // should be in a file-specific structure
       if (!t->bit1_up && !warned_polarity) {
          rlog("*** NOTE: we detected reverse PE signal polarity, but we can handle it\n");
          warned_polarity = true; }

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -547,7 +547,7 @@ void adjust_clock(struct clkavg_t *c, float delta, int trk) {  // update the bit
    }
    else { // *** STRATEGY 3: use a constant instead of averaging
       assert(bpi > 0, "bpi=0 in adjust_clock at %.8lf", timenow);
-      c->t_bitspaceavg = mode & PE+WW ? 1 / (bpi*ips) : nrzi.clkavg.t_bitspaceavg; //
+      c->t_bitspaceavg = (mode & (PE+WW)) ? 1 / (bpi*ips) : nrzi.clkavg.t_bitspaceavg; //
    }
    //if (DEBUG && trace_on && (DEBUGALL || trk == TRACETRK))
       //rlog("trk %d adjust clock of %.2f with delta %.2f uS to %.2f at %.8lf tick %.1lf\n",

--- a/src/dumptap.c
+++ b/src/dumptap.c
@@ -45,6 +45,7 @@ If the options are "-octal -b5500 -linesize=20", the output looks like this:
 14 Oct 2018, L. Shustek, add DEC sixbit character decoding
 17 Dec 2018, L. Shustek, add SDS; change parms to match readtape; display parms;
                          change file naming
+******************************************************************************/
 
 /******************************************************************************
 Copyright (C) 2018, Len Shustek

--- a/src/parmsets.c
+++ b/src/parmsets.c
@@ -85,7 +85,7 @@ char *parmcmds_PE[MAXPARMSETS] = { // commands to set defaults for PE
    "{       1,       5,         0.0,            5,     0.0,       0.0,      1.50,       0.2,          0.7,       0.10,  PRM }",
    "{       1,       5,         0.0,            5,     0.0,       0.0,      1.40,       0.4,          0.7,       0.10,  PRM }",
    "{       1,       3,         0.0,            5,     0.0,       0.0,      1.40,       0.2,          0.7,       0.10,  PRM }",
-   {0 } };
+   0 };
 
 struct parms_t parmsets_NRZI[MAXPARMSETS] = { 0 }; // where we store the NRZI default parmsets
 char *parmcmds_NRZI[MAXPARMSETS] = { // commands to set defaults for NRZI
@@ -98,7 +98,7 @@ char *parmcmds_NRZI[MAXPARMSETS] = { // commands to set defaults for NRZI
    "{        1,       0,      0.200,          1,      0.000,      1.000,      0.500,      0.700,      0.050,      0.500,   PRM }",
    "{        1,       2,      0.000,          1,      0.000,      0.500,      0.500,      0.700,      0.050,      0.500,   PRM }",
    "{        1,       0,      0.600,          1,      0.000,      0.500,      0.500,      0.600,      0.050,      0.500,   PRM }",
-   { 0 } };
+    0 };
 
 struct parms_t parmsets_GCR[MAXPARMSETS] = { 0 }; // where we store the GCR default parmsets
 char *parmcmds_GCR[MAXPARMSETS] = { // commands to set defaults for GCR
@@ -108,14 +108,14 @@ char *parmcmds_GCR[MAXPARMSETS] = { // commands to set defaults for GCR
    "{         1,          0,      0.010,       0,      0.500,      0.200,   0.300,      1.500,      0.200,     1.450,  2.350,   PRM }",
    "{         1,         10,      0.000,       0,      0.500,      0.000,   0.600,      1.500,      0.140,     1.400,  2.300,   PRM }",
    "{         1           0       0.020,       0,      0.500,      0.200,   0.300,      1.500,      0.200,     1.480,  2.350,   PRM }",
-   { 0 } };
+   0 };
 
 struct parms_t parmsets_WW[MAXPARMSETS] = { 0 }; // where we store the Whirlwind default parmsets
 char *parmcmds_WW[MAXPARMSETS] = { // commands to set defaults for GCR
    "parms  active, clk_window, clk_alpha, agc_window, agc_alpha, min_peak, pkww_bitfrac, pkww_rise, id",
    "{         1,          0,      0.050,       0,      0.500,      1.000,    0.400,      0.200,    PRM }",
    "{         1,          0,      0.020,       0,      0.500,      0.050,    0.200,      0.200,    PRM }",
-   { 0 } };
+   0 };
 
 
 struct parms_t parmsets[MAXPARMSETS] = { 0 }; // the parmsets we construct and then use
@@ -203,6 +203,7 @@ void show_parms(struct parms_t *psptr, bool showall) {
             case P_INT: rlog("%10d, ", *(int *)((char*)setptr + parms[i].offset)); break;
             case P_FLT: rlog("%10.3f, ", *(float *)((char*)setptr + parms[i].offset)); break;
             case P_STR: rlog("  %s}", (char *)setptr + parms[i].offset); break; //
+            case P_END: break;
             } }
       if (setptr->comment[0]) rlog(" //%s", setptr->comment);
       else rlog("\n"); }
@@ -243,7 +244,7 @@ void parse_parms(struct parms_t *parmarray, char*(*getnextline)(void)) {
       parm_given[i] = false; }
    struct parms_t *setptr = parmarray;
    char *ptr;
-   while (ptr = (*getnextline)()) {
+   while ((ptr = (*getnextline)())) {
       //rlog("parsing line: %s\n", ptr);
       char str[MAXLINE];
       if (scan_key(&ptr, "//")); // ignore comment line

--- a/src/readtape.c
+++ b/src/readtape.c
@@ -837,7 +837,7 @@ bool opt_str(const char* arg, const char* keyword, const char** str) {
    return true; }
 
 bool opt_filename(const char* arg, const char* keyword, char* path) {
-   char *str;
+   const char *str;
    if (opt_str(arg, keyword, &str)) {
       strncpy(path, str, MAXPATH); path[MAXPATH - 1] = '\0';
       return true; }
@@ -1333,9 +1333,9 @@ void read_tbin_header(void) {  // read the .TBIN file header
       if (tbin_hdr.u.s.flags & TBIN_INVERTED) rlog("  the waveforms were inverted by CSVTBIN\n");
       if (tbin_hdr.u.s.flags & TBIN_REVERSED) rlog("  the tape may have been read or written backwards\n");
       if (tbin_hdr.descr[0] != 0) rlog("   description: %s\n", tbin_hdr.descr);
-      if (tbin_hdr.u.s.time_written.tm_year > 0)   rlog("  created on:   %s", asctime(&tbin_hdr.u.s.time_written));
-      if (tbin_hdr.u.s.time_read.tm_year > 0)      rlog("  read on:      %s", asctime(&tbin_hdr.u.s.time_read));
-      if (tbin_hdr.u.s.time_converted.tm_year > 0) rlog("  converted on: %s", asctime(&tbin_hdr.u.s.time_converted));
+      if (tbin_hdr.u.s.time_written.tm_year > 0)   rlog("  created on:   %s", asctime_unix(&tbin_hdr.u.s.time_written));
+      if (tbin_hdr.u.s.time_read.tm_year > 0)      rlog("  read on:      %s", asctime_unix(&tbin_hdr.u.s.time_read));
+      if (tbin_hdr.u.s.time_converted.tm_year > 0) rlog("  converted on: %s", asctime_unix(&tbin_hdr.u.s.time_converted));
       rlog("  max voltage: %.1fV\n", tbin_hdr.u.s.maxvolts);
       rlog("  time between samples: %.3f usec\n", (float)tbin_hdr.u.s.tdelta / 1000); }
    // (3) read the data section header

--- a/src/readtape.c
+++ b/src/readtape.c
@@ -1066,6 +1066,7 @@ void close_file(void) {
       outf = NULLP; } }
 
 void create_datafile(const char *name) {
+   int res = 0;
    if (outf) close_file();
    if (name) { // we generated a name based on tape labels
       assert(strlen(name) < MAXPATH - 5, "create_datafile name too big 1");
@@ -1073,9 +1074,12 @@ void create_datafile(const char *name) {
       strcat(outdatafilename, ".bin"); }
    else { // otherwise create a generic name
       assert(strlen(baseoutfilename) < MAXPATH - 5, "create_datafile name too big 1");
-      if (tap_format)
-         sprintf(outdatafilename, "%s.tap", baseoutfilename);
-      else sprintf(outdatafilename, "%s.%03d.bin", baseoutfilename, numfiles+1); }
+      if (tap_format) {
+         res = snprintf(outdatafilename, MAXPATH+50, "%s.tap", baseoutfilename);
+         assert(res < MAXPATH, "create_datafile name too big 2"); }
+      else {
+        res = snprintf(outdatafilename, MAXPATH+50, "%s.%03d.bin", baseoutfilename, numfiles+1);
+        assert(res < MAXPATH, "create_datafile name too big 3"); } }
    if (!quiet) rlog("creating file \"%s\"\n", outdatafilename);
    outf = fopen(outdatafilename, "wb");
    assert(outf != NULLP, "file create failed for \"%s\"", outdatafilename);
@@ -1536,6 +1540,7 @@ bool process_file(int argc, char *argv[], const char *extension) {
    char logfilename[MAXPATH];
    char line[MAXLINE + 1];
    bool ok = true;
+   int res = 0;
 
 #if 0 // we no longer create a directory
 #if defined(_WIN32)
@@ -1547,7 +1552,8 @@ bool process_file(int argc, char *argv[], const char *extension) {
 #endif
 
    if (logging) { // Open the log file
-      sprintf(logfilename, "%s.log", baseoutfilename);
+      res = snprintf(logfilename, MAXPATH, "%s.log", baseoutfilename);
+      assert(res < MAXPATH, "logfilename too big");
       assert((rlogf = fopen(logfilename, "w")) != NULLP, "Unable to open log file \"%s\"", logfilename); }
 
    indatafilename[MAXPATH - 5] = '\0';

--- a/src/readtape.c
+++ b/src/readtape.c
@@ -905,6 +905,7 @@ bool parse_skew(const char *arg) { // skew=1.2,4.5,0,0,1   must match ntrks
       skip_blanks(&str);
       if (trk < ntrks_specified - 1) {
          assert(*str == ',', "missing comma in skew list at: %s", str+1);
+         str++;
          skip_blanks(&str); } }
    assert(*str == 0, "extra crap in skew list: %s", str);
    return true; }

--- a/src/readtape.c
+++ b/src/readtape.c
@@ -463,12 +463,12 @@ process_sample, return block status
 
 // file names and handles
 FILE *inf, *outf, *rlogf = NULL, *summf;
-char baseinfilename[MAXPATH];  // (could have a prepended path)
-char baseoutfilename[MAXPATH] = { 0 };
-char outpathname[MAXPATH] = { 0 };
-char summtxtfilename[MAXPATH] = { 0 };
-char summcsvfilename[MAXPATH] = { 0 };
-char outdatafilename[MAXPATH], indatafilename[MAXPATH];
+char baseinfilename[MAXPATH+50];  // (could have a prepended path)
+char baseoutfilename[MAXPATH+50] = { 0 };
+char outpathname[MAXPATH+50] = { 0 };
+char summtxtfilename[MAXPATH+50] = { 0 };
+char summcsvfilename[MAXPATH+50] = { 0 };
+char outdatafilename[MAXPATH+50], indatafilename[MAXPATH+50];
 
 // statistics for the whole tape
 int numblks = 0, numblks_err = 0, numblks_warn = 0, numblks_trksmismatched = 0, numblks_midbiterrs = 0;

--- a/src/textfile.c
+++ b/src/textfile.c
@@ -253,7 +253,7 @@ void txtfile_outputrecord(int length, int errs, int warnings) {
          byte ch = (byte)(data[i] >> 1);
          byte ch2 = (byte)(data[i + 1] >> 1); // in case, for OCT2, we are doing two bytes at once
          if (bufcnt >= txtfile_linesize
-               || txtfile_linefeed && ch == 0x0a) { // start a new line
+               || (txtfile_linefeed && ch == 0x0a)) { // start a new line
             if (txtfile_doboth) output_chars();
             fprintf(txtf, txtfile_verbose ? "\n " : "\n       "); // 7 chars if not verbose
             bufcnt = 0; bufstart = i; }


### PR DESCRIPTION
This set of changes allows readtape to function correctly on macOS and Linux. It also cleans up various compiler warnings (though not all).