### PR TITLE
Makefiles to run the tests

### DIFF
--- a/examples/6trk_Whirlwind/Makefile
+++ b/examples/6trk_Whirlwind/Makefile
@@ -1,0 +1,14 @@
+#!/usr/bin/make -f
+
+READTAPE ?= readtape
+
+all:
+test:
+	$(READTAPE) -whirlwind -v3 -fluxdir=auto -tap -deskew -octal2 -flexo -outp=results/ 132_pt1.tbin
+	for excepcted in expected_results/*.{tap,bin}; do \
+		[ -r "$${expected}" ] || continue; \
+		created="results/$$(basename "$${expected}")"; \
+		cmp "$${expected}" "$${created}" || { echo "$${expected} does not match $${created}." >&2; exit 1; }; \
+	done
+
+.PHONY: all test

--- a/examples/6trk_Whirlwind/results/.gitignore
+++ b/examples/6trk_Whirlwind/results/.gitignore
@@ -1,0 +1,5 @@
+132_pt1.log
+132_pt1.octal2.flexo.txt
+132_pt1.peakstats.csv
+132_pt1.peakstats_deskew.csv
+132_pt1.tap

--- a/examples/7trk_NRZI/Makefile
+++ b/examples/7trk_NRZI/Makefile
@@ -1,0 +1,15 @@
+#!/usr/bin/make -f
+
+READTAPE ?= readtape
+
+all:
+test:
+	$(READTAPE) -v -m -nrzi -ntrks=7 -order=543210p -tap -SDS -linesize=144 -outp=results/ SRI_SDS_102715028_4secs.tbin
+	$(READTAPE) -v -m -nrzi -ntrks=7                -tap                    -outp=results/ tss_4secs.tbin
+	for excepcted in expected_results/*.{tap,bin}; do \
+		[ -r "$${expected}" ] || continue; \
+		created="results/$$(basename "$${expected}")"; \
+		cmp "$${expected}" "$${created}" || { echo "$${expected} does not match $${created}." >&2; exit 1; }; \
+	done
+
+.PHONY: all test

--- a/examples/7trk_NRZI/results/.gitignore
+++ b/examples/7trk_NRZI/results/.gitignore
@@ -1,0 +1,7 @@
+SRI_SDS_102715028_4secs.SDS.txt
+SRI_SDS_102715028_4secs.log
+SRI_SDS_102715028_4secs.peakstats.csv
+SRI_SDS_102715028_4secs.tap
+tss_4secs.log
+tss_4secs.peakstats.csv
+tss_4secs.tap

--- a/examples/9trk_GCR/Makefile
+++ b/examples/9trk_GCR/Makefile
@@ -1,0 +1,16 @@
+#!/usr/bin/make -f
+
+READTAPE ?= readtape
+
+all:
+test:
+	$(READTAPE) -v -m -gcr -ips=50 -order=76543210p -zeros -correct -tap -ascii -linefeed -outp=results/ 1kblks_43blks.tbin
+	$(READTAPE) -v -m -gcr -ips=50                  -zeros -correct -tap -ascii -linefeed -outp=results/ sf93_8blks.tbin
+	$(READTAPE) -v    -gcr -ips=125 -differentiate  -zeros          -tap -ascii           -outp=results/ analog.tbin
+	for excepcted in expected_results/*.{tap,bin}; do \
+		[ -r "$${expected}" ] || continue; \
+		created="results/$$(basename "$${expected}")"; \
+		cmp "$${expected}" "$${created}" || { echo "$${expected} does not match $${created}." >&2; exit 1; }; \
+	done
+
+.PHONY: all test

--- a/examples/9trk_GCR/results/.gitignore
+++ b/examples/9trk_GCR/results/.gitignore
@@ -1,0 +1,12 @@
+1kblks_43blks.ASCII.txt
+1kblks_43blks.log
+1kblks_43blks.peakstats.csv
+1kblks_43blks.tap
+analog.ASCII.txt
+analog.log
+analog.peakstats.csv
+analog.tap
+sf93_8blks.ASCII.txt
+sf93_8blks.log
+sf93_8blks.peakstats.csv
+sf93_8blks.tap

--- a/examples/9trk_NRZI/Makefile
+++ b/examples/9trk_NRZI/Makefile
@@ -1,0 +1,15 @@
+#!/usr/bin/make -f
+
+READTAPE ?= readtape
+
+all:
+test:
+	$(READTAPE) -v -m -nrzi -ips=50 -deskew -ebcdic -linefeed -outp=results/ PLAGO_beginning.tbin
+	$(READTAPE) -v -m -nrzi -hex            -ascii            -outp=results/ Microdata_20blks.tbin
+	for excepcted in expected_results/*.{tap,bin}; do \
+		[ -r "$${expected}" ] || continue; \
+		created="results/$$(basename "$${expected}")"; \
+		cmp "$${expected}" "$${created}" || { echo "$${expected} does not match $${created}." >&2; exit 1; }; \
+	done
+
+.PHONY: all test

--- a/examples/9trk_NRZI/results/.gitignore
+++ b/examples/9trk_NRZI/results/.gitignore
@@ -1,0 +1,11 @@
+Microdata_20blks.001.bin
+Microdata_20blks.hex.ASCII.txt
+Microdata_20blks.log
+Microdata_20blks.peakstats.csv
+PLAGO_beginning-001-DOCUMENT.bin
+PLAGO_beginning-002-PLAGO.bin
+PLAGO_beginning-003-IDOSEM.bin
+PLAGO_beginning.EBCDIC.txt
+PLAGO_beginning.log
+PLAGO_beginning.peakstats.csv
+PLAGO_beginning.peakstats_deskew.csv

--- a/examples/9trk_PE/Makefile
+++ b/examples/9trk_PE/Makefile
@@ -1,0 +1,15 @@
+#!/usr/bin/make -f
+
+READTAPE ?= readtape
+
+all:
+test:
+	$(READTAPE) -v -m -ntrks=9 -pe -bpi=1600 -ips=50 -order=01234576p -tap -ascii  -linefeed     -outp=results/ 1600bpi_ukn_6s.tbin
+	$(READTAPE) -v -m -ntrks=9 -pe -bpi=1600 -ips=50                  -tap -ebcdic -linesize=137 -outp=results/ LJS009_part1_39blks.tbin
+	for excepcted in expected_results/*.{tap,bin}; do \
+		[ -r "$${expected}" ] || continue; \
+		created="results/$$(basename "$${expected}")"; \
+		cmp "$${expected}" "$${created}" || { echo "$${expected} does not match $${created}." >&2; exit 1; }; \
+	done
+
+.PHONY: all test

--- a/examples/9trk_PE/results/.gitignore
+++ b/examples/9trk_PE/results/.gitignore
@@ -1,0 +1,8 @@
+1600bpi_ukn_6s.ASCII.txt
+1600bpi_ukn_6s.log
+1600bpi_ukn_6s.peakstats.csv
+1600bpi_ukn_6s.tap
+LJS009_part1_39blks.EBCDIC.txt
+LJS009_part1_39blks.log
+LJS009_part1_39blks.peakstats.csv
+LJS009_part1_39blks.tap

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,12 @@
+#!/usr/bin/make -f
+
+SUBDIRS := $(wildcard */.)
+READTAPE ?= ../../src/readtape
+
+all:
+test: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) READTAPE=$(READTAPE) -C $@ test
+
+.PHONY: all test $(SUBDIRS)

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -11,3 +11,7 @@ Tape blocks were selected so that the .tbin files are (mostly) less than 50 MB, 
 You can run all the tests with "runtests.bat", which puts your output files in the various "results" directories.
 The batch file then compares the .tap or.bin files in the "results" and "expected_result" directories, and
 pauses if there are differences. The various text files (.log, .txt) might have minor inconsequential differences.
+As an alternative, you can run all tests by invoking `make -C examples test`, which will generate output for all
+tape blocks and compare it to expected results. Individual tests can be run by
+`make READTAPE=../../src/readtape -C examples/6trk_Whirlwind/ test` (so the `readtape` to be used for a test
+can be given at the command line.)


### PR DESCRIPTION
I've setup an auto-builder to build `readtape`, these Makefiles aid in being able to easily run the tests on GNU hosts (Linux for me.) It will run a `make test` in any subdirectory of `./examples/` and check that all output (as expected in the `./examples/*/expected_results/*.{tap,bin}` files) was properly created.