### PR TITLE
Fix WIN32 regression

### DIFF
--- a/src/readtape.c
+++ b/src/readtape.c
@@ -644,7 +644,7 @@ void makedir(const char *dirname) {
 char *parentdir(const char *filename) {
    char *fullpath = NULLP;
 #if defined (_WIN32)
-   fullpath = _fullpath(filename, NULL, MAXPATH);
+   fullpath = _fullpath(NULL, filename, MAXPATH);
 #else
    fullpath = realpath(filename, NULLP);
 #endif


### PR DESCRIPTION
Arguments to Win32's `_fullpath()` are reversed from POSIX's `realpath()`.

@LenShustek this addresses a crash one user on the ClassicCmp Discord server reported. A new `readtape.exe` binary will need to be committed with this fix.